### PR TITLE
Add periodic execution decorators and usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,46 @@ async def main():
     await db.close()
 ```
 
+## Usage examples
+
+The `BaseDB` API offers helpers for common operations and background tasks:
+
+```python
+from scriptdb import BaseDB, run_every_seconds, run_every_queries
+
+class MyDB(BaseDB):
+    def migrations(self):
+        return [
+            {"name": "init", "sql": "CREATE TABLE t(id INTEGER PRIMARY KEY, x INTEGER)"}
+        ]
+
+    # Periodically remove rows older than a minute
+    @run_every_seconds(60)
+    async def cleanup(self):
+        await self.execute("DELETE FROM t WHERE x < 0")
+
+    # Write a checkpoint every 100 executed queries
+    @run_every_queries(100)
+    async def checkpoint(self):
+        await self.execute("PRAGMA wal_checkpoint")
+
+async def main():
+    db = await MyDB.open("app.db")
+
+    # Insert many rows at once
+    await db.execute_many("INSERT INTO t(x) VALUES(?)", [(1,), (2,), (3,)])
+
+    # Fetch all rows
+    rows = await db.query_many("SELECT x FROM t")
+    print([r["x"] for r in rows])
+
+    # Stream rows one by one
+    async for row in db.query_many_gen("SELECT x FROM t"):
+        print(row["x"])
+
+    await db.close()
+```
+
 ## Running tests
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ async def main():
 
 ## Usage examples
 
-The `BaseDB` API offers helpers for common operations and background tasks:
+The `BaseDB` API supports migrations and offers helpers for common operations
+and background tasks:
 
 ```python
 from scriptdb import BaseDB, run_every_seconds, run_every_queries
@@ -59,7 +60,15 @@ from scriptdb import BaseDB, run_every_seconds, run_every_queries
 class MyDB(BaseDB):
     def migrations(self):
         return [
-            {"name": "init", "sql": "CREATE TABLE t(id INTEGER PRIMARY KEY, x INTEGER)"}
+            {"name": "init", "sql": """
+                CREATE TABLE t(
+                    id INTEGER PRIMARY KEY,
+                    x INTEGER NOT NULL,
+                    created_at INTEGER NOT NULL
+                )
+            """},
+            {"name": "add_index", "sql": "CREATE INDEX idx_t_created_at ON t(created_at)"},
+            {"name": "create_meta", "sql": "CREATE TABLE meta(key TEXT PRIMARY KEY, value TEXT)"},
         ]
 
     # Periodically remove rows older than a minute

--- a/src/scriptdb/__init__.py
+++ b/src/scriptdb/__init__.py
@@ -1,6 +1,6 @@
 """Async SQLite database with migrations for lightweight scripts."""
 
-from .basedb import BaseDB
+from .basedb import BaseDB, run_every_seconds, run_every_queries
 
-__all__ = ["BaseDB"]
+__all__ = ["BaseDB", "run_every_seconds", "run_every_queries"]
 __version__ = "0.1.0"

--- a/src/scriptdb/basedb.py
+++ b/src/scriptdb/basedb.py
@@ -41,7 +41,8 @@ def require_init(method: Callable) -> Callable:
 
 
 def run_every_seconds(seconds: int) -> Callable:
-    """Run decorated async method in background every ``seconds``.
+    """Decorator for async methods of :class:`BaseDB` subclasses to run in
+    background every ``seconds``.
 
     Useful for periodic cleaners or updaters that should work while the
     database connection stays open.
@@ -63,7 +64,8 @@ def run_every_seconds(seconds: int) -> Callable:
 
 
 def run_every_queries(queries: int) -> Callable:
-    """Run decorated async method after every ``queries`` database calls.
+    """Decorator for async methods of :class:`BaseDB` subclasses to run after
+    every ``queries`` database calls.
 
     Handy for tasks like checkpointing or vacuuming triggered by activity.
 

--- a/tests/test_basedb.py
+++ b/tests/test_basedb.py
@@ -1,3 +1,4 @@
+import asyncio
 import pytest
 import pytest_asyncio
 import sys
@@ -5,7 +6,7 @@ import pathlib
 
 # Add the src directory to sys.path so we can import the package
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / 'src'))
-from scriptdb import BaseDB
+from scriptdb import BaseDB, run_every_seconds, run_every_queries
 
 
 class MyTestDB(BaseDB):
@@ -127,3 +128,51 @@ class MissingSqlFuncDB(BaseDB):
 async def test_missing_sql_and_function(tmp_path):
     with pytest.raises(ValueError):
         await MissingSqlFuncDB.open(str(tmp_path / "bad2.sqlite"))
+
+
+class PeriodicDB(BaseDB):
+    def __init__(self, path: str):
+        super().__init__(path)
+        self.calls = 0
+
+    def migrations(self):
+        return []
+
+    @run_every_seconds(0.05)
+    async def tick(self):
+        self.calls += 1
+
+
+@pytest.mark.asyncio
+async def test_run_every_seconds(tmp_path):
+    db = await PeriodicDB.open(str(tmp_path / "periodic.sqlite"))
+    try:
+        await asyncio.sleep(0.12)
+        assert db.calls >= 2
+    finally:
+        await db.close()
+
+
+class QueryHookDB(BaseDB):
+    def __init__(self, path: str):
+        super().__init__(path)
+        self.calls = 0
+
+    def migrations(self):
+        return []
+
+    @run_every_queries(2)
+    async def hook(self):
+        self.calls += 1
+
+
+@pytest.mark.asyncio
+async def test_run_every_queries(tmp_path):
+    db = await QueryHookDB.open(str(tmp_path / "hook.sqlite"))
+    try:
+        await db.query_one("SELECT 1")
+        await db.query_one("SELECT 1")
+        await asyncio.sleep(0)  # allow hook to run
+        assert db.calls == 1
+    finally:
+        await db.close()


### PR DESCRIPTION
## Summary
- add `run_every_seconds` decorator to schedule background coroutine execution
- add `run_every_queries` decorator to trigger tasks after N DB calls
- document new helpers and existing APIs in README
- export decorators and cover them with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68932d890cb08324bb206286f1e90ee5