### PR TITLE
feat: add CRUD helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,29 @@ async def main():
     await db.close()
 ```
 
+### Helper methods
+
+`BaseDB` includes convenience helpers for common insert, update and delete
+operations:
+
+```python
+# Insert one row and get its primary key
+pk = await db.insert_one("t", {"x": 1})
+
+# Insert many rows
+await db.insert_many("t", [{"x": 2}, {"x": 3}])
+
+# Upsert a single row
+await db.upsert_one("t", {"id": pk, "x": 10})
+
+# Upsert many rows
+await db.upsert_many("t", [{"id": 1, "x": 11}, {"id": 4, "x": 4}])
+
+# Delete rows
+await db.delete_one("t", pk)
+await db.delete_many("t", "x < ?", (0,))
+```
+
 ## Running tests
 
 ```bash


### PR DESCRIPTION
## Summary
- support insert, upsert and delete helpers in `BaseDB`
- document CRUD helpers in the README
- add unit tests covering CRUD helpers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689434e9c8a48324824db348c7e68efa