### PR TITLE
Add query helper methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,34 @@ await db.delete_one("t", pk)
 await db.delete_many("t", "x < ?", (0,))
 ```
 
+### Query helpers
+
+The library also offers helpers for common read patterns:
+
+```python
+# Get a single value
+count = await db.query_scalar("SELECT COUNT(*) FROM t")
+
+# Get a list from the first column of each row
+ids = await db.query_column("SELECT id FROM t ORDER BY id")
+
+# Build dictionaries from rows
+# Use primary key automatically
+users = await db.query_dict("SELECT * FROM users")
+
+# Explicit column names for key and value
+names = await db.query_dict(
+    "SELECT id, name FROM users", key="id", value="name"
+)
+
+# Callables for custom key and value
+full_names = await db.query_dict(
+    "SELECT * FROM users",
+    key=lambda r: r["id"],
+    value=lambda r: f"{r['first_name']} {r['last_name']}",
+)
+```
+
 ## Running tests
 
 ```bash

--- a/src/scriptdb/basedb.py
+++ b/src/scriptdb/basedb.py
@@ -4,6 +4,7 @@ import asyncio
 import inspect
 import logging
 import contextlib
+import re
 import aiosqlite
 from typing import Any, Callable, Dict, List, Set, Optional, Sequence, Iterable, Mapping, Union, Type, TypeVar, AsyncGenerator, Tuple
 
@@ -503,6 +504,95 @@ class BaseDB(abc.ABC):
         await cur.close()
         self._on_query()
         return row
+
+    @require_init
+    async def query_scalar(
+        self,
+        sql: str,
+        params: Union[Sequence[Any], Mapping[str, Any], None] = None,
+    ) -> Any:
+        """Execute a query and return the first column of the first row.
+
+        Example:
+            count = await db.query_scalar(
+                "SELECT COUNT(*) FROM t WHERE x > ?", (0,)
+            )
+        """
+        row = await self.query_one(sql, params)
+        return None if row is None else row[0]
+
+    @require_init
+    async def query_column(
+        self,
+        sql: str,
+        params: Union[Sequence[Any], Mapping[str, Any], None] = None,
+    ) -> List[Any]:
+        """Execute a query and return a list of the first column from each row.
+
+        Example:
+            ids = await db.query_column(
+                "SELECT id FROM t WHERE x > ?", (0,)
+            )
+        """
+        rows = await self.query_many(sql, params)
+        return [row[0] for row in rows]
+
+    @require_init
+    async def query_dict(
+        self,
+        sql: str,
+        params: Union[Sequence[Any], Mapping[str, Any], None] = None,
+        *,
+        key: Union[str, Callable[[sqlite3.Row], Any], None] = None,
+        value: Union[str, Callable[[sqlite3.Row], Any], None] = None,
+    ) -> Dict[Any, Any]:
+        """Execute a query and return a dictionary built from rows.
+
+        ``key`` may be a column name, a callable receiving each row, or ``None``
+        to automatically use the table's primary key column.
+
+        ``value`` controls the dictionary's values. When ``None`` (default) each
+        row is stored. If a string, the named column from each row is used. If a
+        callable, its return value is stored for each row.
+
+        Examples:
+            # Use primary key column automatically
+            users = await db.query_dict("SELECT * FROM users")
+
+            # Explicit column names for key and value
+            names = await db.query_dict(
+                "SELECT id, name FROM users", key="id", value="name"
+            )
+
+            # Callables for custom key and value
+            users = await db.query_dict(
+                "SELECT * FROM users",
+                key=lambda row: row["id"],
+                value=lambda row: f"{row['first_name']} {row['last_name']}",
+            )
+        """
+        rows = await self.query_many(sql, params)
+
+        if key is None:
+            match = re.search(r"from\s+([A-Za-z_][\w]*)", sql, re.IGNORECASE)
+            if not match:
+                raise ValueError("Cannot determine table name; provide 'key'")
+            table = match.group(1)
+            key = await self._primary_key(table)
+
+        if isinstance(key, str):
+            get_key = lambda row, k=key: row[k]
+        else:
+            get_key = key
+
+        if value is None:
+            get_value = lambda row: row
+        elif isinstance(value, str):
+            get_value = lambda row, v=value: row[v]
+        else:
+            get_value = value
+
+        return {get_key(row): get_value(row) for row in rows}
 
     @require_init
     async def close(self) -> None:

--- a/src/scriptdb/basedb.py
+++ b/src/scriptdb/basedb.py
@@ -574,10 +574,17 @@ class BaseDB(abc.ABC):
         rows = await self.query_many(sql, params)
 
         if key is None:
-            match = re.search(r"from\s+([A-Za-z_][\w]*)", sql, re.IGNORECASE)
+            match = re.search(
+                r"from\s+(?:\"([A-Za-z_][\w]*)\"|'([A-Za-z_][\w]*)'|([A-Za-z_][\w]*))",
+                sql,
+                re.IGNORECASE,
+            )
             if not match:
-                raise ValueError("Cannot determine table name; provide 'key'")
-            table = match.group(1)
+                raise ValueError(
+                    "Cannot determine table name from sql, so cannot deduce primary "
+                    "key, please provide non-empty 'key' argument"
+                )
+            table = match.group(1) or match.group(2) or match.group(3)
             key = await self._primary_key(table)
 
         if isinstance(key, str):

--- a/tests/test_basedb.py
+++ b/tests/test_basedb.py
@@ -154,6 +154,17 @@ async def test_query_dict(db):
     )
     assert doubled == {1: 2, 2: 4}
 
+    # Quoted table name still resolves primary key
+    quoted = await db.query_dict('SELECT id, x FROM "t"')
+    assert set(quoted.keys()) == {1, 2}
+
+
+@pytest.mark.asyncio
+async def test_query_dict_requires_key_when_table_unknown(db):
+    with pytest.raises(ValueError) as exc:
+        await db.query_dict("SELECT 1")
+    assert "Cannot determine table name from sql" in str(exc.value)
+
 
 @pytest.mark.asyncio
 async def test_close_sets_initialized_false(tmp_path):


### PR DESCRIPTION
## Summary
- add `query_scalar`, `query_column`, and `query_dict` helpers
- document new helpers in README
- cover helpers with unit tests

## Testing
- `pip install -e .[test]`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689469cdd7d88324bae6064b7257b006