### PR TITLE
Add tests for composite primary key handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ pleasant developer experience while keeping the API minimal.
 * **Lightweight** – no server to run and no complicated setup; perfect for
   throw‑away scripts or small tools.
 
+Composite primary keys are not supported; each table must have a single-column primary key.
+
 ## Installation
 
 The project can be installed from source:

--- a/src/scriptdb/basedb.py
+++ b/src/scriptdb/basedb.py
@@ -236,12 +236,12 @@ class BaseDB(abc.ABC):
             cur = await self.conn.execute(sql)
             rows = await cur.fetchall()
             await cur.close()
-            for row in rows:
-                if row["pk"]:
-                    self._pk_cache[table] = row["name"]
-                    break
-            else:
+            pk_cols = [row["name"] for row in rows if row["pk"]]
+            if not pk_cols:
                 raise ValueError(f"Table {table} has no primary key")
+            if len(pk_cols) > 1:
+                raise ValueError(f"Table {table} has composite primary key")
+            self._pk_cache[table] = pk_cols[0]
         return self._pk_cache[table]
 
     def _on_query(self) -> None:

--- a/tests/test_composite_pk.py
+++ b/tests/test_composite_pk.py
@@ -1,0 +1,65 @@
+import sys
+import pathlib
+import pytest
+import pytest_asyncio
+
+# Add the src directory to sys.path so we can import the package
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / 'src'))
+from scriptdb import BaseDB
+
+
+class CompositePKDB(BaseDB):
+    def migrations(self):
+        return [
+            {
+                "name": "create_table",
+                "sql": "CREATE TABLE t(a INTEGER, b INTEGER, x INTEGER, PRIMARY KEY (a, b))",
+            }
+        ]
+
+
+@pytest_asyncio.fixture
+async def db(tmp_path):
+    db_file = tmp_path / "test.db"
+    db = await CompositePKDB.open(str(db_file))
+    try:
+        yield db
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_insert_one_composite_primary_key(db):
+    with pytest.raises(ValueError) as exc:
+        await db.insert_one("t", {"a": 1, "b": 2, "x": 3})
+    assert "composite primary key" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_upsert_one_composite_primary_key(db):
+    with pytest.raises(ValueError) as exc:
+        await db.upsert_one("t", {"a": 1, "b": 2, "x": 3})
+    assert "composite primary key" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_upsert_many_composite_primary_key(db):
+    rows = [{"a": 1, "b": 2, "x": 3}, {"a": 3, "b": 4, "x": 5}]
+    with pytest.raises(ValueError) as exc:
+        await db.upsert_many("t", rows)
+    assert "composite primary key" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_delete_one_composite_primary_key(db):
+    with pytest.raises(ValueError) as exc:
+        await db.delete_one("t", 1)
+    assert "composite primary key" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_query_dict_composite_primary_key(db):
+    await db.execute("INSERT INTO t(a, b, x) VALUES(?, ?, ?)", (1, 2, 3))
+    with pytest.raises(ValueError) as exc:
+        await db.query_dict("SELECT * FROM t")
+    assert "composite primary key" in str(exc.value)


### PR DESCRIPTION
## Summary
- raise an error when a table uses a composite primary key
- test automatic primary key lookups on composite key tables across insert, upsert, delete, and query utilities

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68948203ccb88324a96d2eacbff3f161