### PR TITLE
Add CacheDB for expiring key-value caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,44 @@ full_names = await db.query_dict(
 )
 ```
 
+## Useful implementations
+
+### CacheDB
+
+`CacheDB` provides a simple key‑value store with optional expiration. Because
+it inherits from `BaseDB`, it is created and used the same way as other
+databases in the library.
+
+```python
+from scriptdb import CacheDB
+
+async def main():
+    cache = await CacheDB.open("cache.db")
+    await cache.set("answer", b"42", expire_sec=60)
+    if await cache.is_set("answer"):
+        print("cached!")
+    print(await cache.get("answer"))  # b"42"
+    await cache.close()
+```
+
+A value without `expire_sec` will be kept indefinitely. Use `is_set` to check for
+keys without retrieving their values. To easily cache
+function results, use the decorator:
+
+```python
+import asyncio
+from scriptdb.cachedb import cache
+
+@cache(expire_sec=30)
+async def slow():
+    await asyncio.sleep(1)
+    return 1
+```
+
+Subsequent calls within 30 seconds will return the cached result without
+executing the function. You can supply `key_func` to control how the cache key
+is generated.
+
 ## Running tests
 
 ```bash

--- a/src/scriptdb/__init__.py
+++ b/src/scriptdb/__init__.py
@@ -1,6 +1,7 @@
 """Async SQLite database with migrations for lightweight scripts."""
 
 from .basedb import BaseDB, run_every_seconds, run_every_queries
+from .cachedb import CacheDB
 
-__all__ = ["BaseDB", "run_every_seconds", "run_every_queries"]
+__all__ = ["BaseDB", "run_every_seconds", "run_every_queries", "CacheDB"]
 __version__ = "0.1.0"

--- a/src/scriptdb/cachedb.py
+++ b/src/scriptdb/cachedb.py
@@ -1,0 +1,131 @@
+import sqlite3
+import pickle
+import inspect
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable, List, Optional
+
+from .basedb import BaseDB, run_every_seconds, require_init
+
+
+class CacheDB(BaseDB):
+    """SQLite-backed cache database with expiration support."""
+
+    def migrations(self):
+        return [
+            {
+                "name": "create_cache_table",
+                "sql": (
+                    "CREATE TABLE IF NOT EXISTS cache ("
+                    "key TEXT PRIMARY KEY,"
+                    "value BLOB NOT NULL,"
+                    "expire_utc DATETIME"
+                    ")"
+                ),
+            }
+        ]
+
+    @require_init
+    async def get(self, key: str, default: Any = None) -> Any:
+        row = await self.query_one(
+            "SELECT value, expire_utc FROM cache WHERE key=?", (key,)
+        )
+        if row is None:
+            return default
+        expire_utc = row["expire_utc"]
+        if expire_utc is not None:
+            if datetime.fromisoformat(expire_utc) <= datetime.now(timezone.utc):
+                return default
+        return pickle.loads(row["value"])
+
+    @require_init
+    async def is_set(self, key: str) -> bool:
+        """Return ``True`` if ``key`` exists and is not expired."""
+        exists = await self.query_scalar(
+            "SELECT 1 FROM cache WHERE key=? AND (expire_utc IS NULL OR expire_utc > ?)",
+            (key, datetime.now(timezone.utc).isoformat()),
+        )
+        return exists is not None
+
+    @require_init
+    async def set(
+        self, key: str, value: Any, expire_sec: Optional[int] = None
+    ) -> None:
+        now = datetime.now(timezone.utc)
+        if expire_sec is None:
+            expire_utc = None
+        elif expire_sec > 0:
+            expire_utc = now + timedelta(seconds=expire_sec)
+        else:
+            expire_utc = now
+        blob = sqlite3.Binary(pickle.dumps(value))
+        row = {
+            "key": key,
+            "value": blob,
+            "expire_utc": expire_utc.isoformat() if expire_utc else None,
+        }
+        await self.upsert_one("cache", row)
+
+    @require_init
+    async def delete(self, key: str) -> int:
+        cur = await self.execute("DELETE FROM cache WHERE key=?", (key,))
+        return cur.rowcount
+
+    @require_init
+    async def del_many(self, key_mask: str) -> int:
+        pattern = key_mask.replace("_", "\\_").replace("*", "%")
+        cur = await self.execute(
+            "DELETE FROM cache WHERE key LIKE ? ESCAPE '\\'", (pattern,)
+        )
+        return cur.rowcount
+
+    @require_init
+    async def keys(self, key_mask: str) -> List[str]:
+        pattern = key_mask.replace("_", "\\_").replace("*", "%")
+        return await self.query_column(
+            "SELECT key FROM cache WHERE key LIKE ? ESCAPE '\\' AND (expire_utc IS NULL OR expire_utc > ?)",
+            (pattern, datetime.now(timezone.utc).isoformat()),
+        )
+
+    @require_init
+    async def clear(self) -> int:
+        cur = await self.execute("DELETE FROM cache")
+        return cur.rowcount
+
+    def cache(
+        self,
+        expire_sec: Optional[int] = None,
+        key_func: Optional[Callable[..., str]] = None,
+    ) -> Callable:
+        def decorator(func: Callable) -> Callable:
+            async def wrapper(*args, **kwargs):
+                key = (
+                    key_func(*args, **kwargs)
+                    if key_func
+                    else f"{func.__name__}:{args}:{kwargs}"
+                )
+                _sentinel = object()
+                value = await self.get(key, _sentinel)
+                if value is not _sentinel:
+                    return value
+                if inspect.iscoroutinefunction(func):
+                    result = await func(*args, **kwargs)
+                else:
+                    result = func(*args, **kwargs)
+                await self.set(key, result, expire_sec)
+                return result
+
+            return wrapper
+
+        return decorator
+
+    @run_every_seconds(5)
+    @require_init
+    async def _cleanup(self) -> None:
+        await self.execute(
+            "DELETE FROM cache WHERE expire_utc IS NOT NULL AND expire_utc <= ?",
+            (datetime.now(timezone.utc).isoformat(),),
+        )
+
+
+# Alias to comply with 'del' name
+setattr(CacheDB, 'del', CacheDB.delete)

--- a/tests/test_cachedb.py
+++ b/tests/test_cachedb.py
@@ -1,0 +1,111 @@
+import asyncio
+import pytest
+import pytest_asyncio
+import sys
+import pathlib
+
+# add src path
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / 'src'))
+from scriptdb import CacheDB
+
+
+@pytest_asyncio.fixture
+async def db(tmp_path):
+    db_file = tmp_path / 'cache.db'
+    db = await CacheDB.open(str(db_file))
+    try:
+        yield db
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_cache_table_created(db):
+    row = await db.query_one("SELECT name FROM sqlite_master WHERE name='cache'")
+    assert row is not None
+
+
+@pytest.mark.asyncio
+async def test_set_get_delete(db):
+    await db.set('a', {'x': 1})
+    assert await db.get('a') == {'x': 1}
+    await db.delete('a')
+    assert await db.get('a') is None
+
+
+@pytest.mark.asyncio
+async def test_is_set(db):
+    await db.set('a', 1)
+    assert await db.is_set('a') is True
+    await db.delete('a')
+    assert await db.is_set('a') is False
+    await db.set('b', 1, expire_sec=0)
+    assert await db.is_set('b') is False
+
+
+@pytest.mark.asyncio
+async def test_del_many_keys_clear(db):
+    await db.set('a_1', 1, 60)
+    await db.set('a_2', 2, 60)
+    await db.set('b_1', 3, 60)
+    keys = await db.keys('a_*')
+    assert set(keys) == {'a_1', 'a_2'}
+    await db.del_many('a_*')
+    keys = await db.keys('*')
+    assert keys == ['b_1']
+    await db.clear()
+    assert await db.keys('*') == []
+
+
+@pytest.mark.asyncio
+async def test_cache_decorator(db):
+    calls = {'add': 0}
+
+    @db.cache(expire_sec=1)
+    async def add(a, b):
+        calls['add'] += 1
+        return a + b
+
+    assert await add(1, 2) == 3
+    assert await add(1, 2) == 3
+    assert calls['add'] == 1
+    await asyncio.sleep(1.1)
+    assert await add(1, 2) == 3
+    assert calls['add'] == 2
+
+    calls['sq'] = 0
+
+    @db.cache(key_func=lambda x: f"sq:{x}")
+    async def square(x):
+        calls['sq'] += 1
+        return x * x
+
+    assert await square(4) == 16
+    await asyncio.sleep(1.1)
+    assert await square(4) == 16
+    assert calls['sq'] == 1
+
+
+@pytest.mark.asyncio
+async def test_cache_decorator_sync(db):
+    calls = {'mul': 0}
+
+    @db.cache(expire_sec=1)
+    def mul(a, b):
+        calls['mul'] += 1
+        return a * b
+
+    assert await mul(2, 3) == 6
+    assert await mul(2, 3) == 6
+    assert calls['mul'] == 1
+
+
+@pytest.mark.asyncio
+async def test_cleanup_expired(db):
+    await db.set('temp', 'v', 0)
+    await db.set('perm', 'v')
+    count = await db.query_scalar('SELECT COUNT(*) FROM cache')
+    assert count == 2
+    await asyncio.sleep(5.5)
+    count = await db.query_scalar('SELECT COUNT(*) FROM cache')
+    assert count == 1


### PR DESCRIPTION
## Summary
- add `is_set` to check for key existence without fetching values
- document `is_set` usage in README
- test `is_set` for existing and expired keys

## Testing
- `pip install -e .[test]`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689484184694832484838126df1d56ec