### PR TITLE
Add update_one and async context manager

### DIFF
--- a/tests/test_cachedb.py
+++ b/tests/test_cachedb.py
@@ -12,11 +12,8 @@ from scriptdb import CacheDB
 @pytest_asyncio.fixture
 async def db(tmp_path):
     db_file = tmp_path / 'cache.db'
-    db = await CacheDB.open(str(db_file))
-    try:
+    async with CacheDB.open(str(db_file)) as db:
         yield db
-    finally:
-        await db.close()
 
 
 @pytest.mark.asyncio
@@ -109,3 +106,11 @@ async def test_cleanup_expired(db):
     await asyncio.sleep(5.5)
     count = await db.query_scalar('SELECT COUNT(*) FROM cache')
     assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_async_with_closes(tmp_path):
+    db_file = tmp_path / 'ctx.db'
+    async with CacheDB.open(str(db_file)) as db:
+        await db.set('a', 1)
+    assert db.initialized is False

--- a/tests/test_composite_pk.py
+++ b/tests/test_composite_pk.py
@@ -21,11 +21,8 @@ class CompositePKDB(BaseDB):
 @pytest_asyncio.fixture
 async def db(tmp_path):
     db_file = tmp_path / "test.db"
-    db = await CompositePKDB.open(str(db_file))
-    try:
+    async with CompositePKDB.open(str(db_file)) as db:
         yield db
-    finally:
-        await db.close()
 
 
 @pytest.mark.asyncio
@@ -54,6 +51,13 @@ async def test_upsert_many_composite_primary_key(db):
 async def test_delete_one_composite_primary_key(db):
     with pytest.raises(ValueError) as exc:
         await db.delete_one("t", 1)
+    assert "composite primary key" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_update_one_composite_primary_key(db):
+    with pytest.raises(ValueError) as exc:
+        await db.update_one("t", 1, {"x": 4})
     assert "composite primary key" in str(exc.value)
 
 


### PR DESCRIPTION
## Summary
- Rename helper to `_BaseDBOpenContext` and document its role in `BaseDB.open`
- Document manual `open()`/`close()` usage alongside context manager example
- Enforce migration `function` entries to be async and call them with database, full list, and current name
- Add `update_one` and support `async with` by implementing `__aenter__`/`__aexit__`
- Rewrite README examples around a realistic `resources` table

## Testing
- `pip install -e .[test]`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689525df2bfc832490faad4c7591e445