### PR TITLE
Warn when aiosqlite is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog of the ScriptDB
 
+## 1.0.2 - Lazy async imports
+
+### Added
+
+* Deferred loading of async components so `SyncBaseDB` works without `aiosqlite`
+* Clear guidance when `aiosqlite` is missing
+* Tests covering public exports and sync-only operation
+
 ## 1.0.1 - Slight changes
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scriptdb"
-version = "1.0.1"
+version = "1.0.2"
 description = "Simple SQLite sync/async wrapper with migration support for use in ad-hoc scripts"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/scriptdb/__init__.py
+++ b/src/scriptdb/__init__.py
@@ -8,9 +8,7 @@ if sqlite3.sqlite_version_info < MIN_SQLITE_VERSION:  # pragma: no cover - env g
     raise RuntimeError("ScriptDB requires SQLite >= 3.21.0")
 
 from .abstractdb import AbstractBaseDB, run_every_seconds, run_every_queries
-from .asyncdb import AsyncBaseDB
 from .syncdb import SyncBaseDB
-from .cachedb import AsyncCacheDB, SyncCacheDB
 
 __all__ = [
     "AbstractBaseDB",
@@ -21,4 +19,38 @@ __all__ = [
     "AsyncCacheDB",
     "SyncCacheDB",
 ]
-__version__ = "0.1.0"
+__version__ = "1.0.2"
+
+
+# Lazy-load objects that require optional dependencies so that importing
+# :mod:`scriptdb` does not immediately pull them in.  The synchronous API is
+# always available, while the async and cache implementations are resolved on
+# first access.
+_LAZY_ATTRS = {
+    "AsyncBaseDB": ("asyncdb", "AsyncBaseDB"),
+    "AsyncCacheDB": ("cachedb", "AsyncCacheDB"),
+    "SyncCacheDB": ("cachedb", "SyncCacheDB"),
+}
+
+
+def __getattr__(name: str):
+    """Dynamically import optional components.
+
+    ``AsyncBaseDB`` depends on :mod:`aiosqlite`, so we delay importing it until
+    needed.  The cache database variants live in :mod:`cachedb` and are loaded
+    on demand as well.  All other public names are imported eagerly above.
+    """
+
+    if name in _LAZY_ATTRS:
+        module_name, attr_name = _LAZY_ATTRS[name]
+        try:
+            module = __import__(f"{__name__}.{module_name}", fromlist=[attr_name])
+        except ImportError as exc:  # pragma: no cover - runtime guard
+            if name == "AsyncBaseDB":
+                raise ImportError(
+                    "aiosqlite is required for async support; install with 'scriptdb[async]'"
+                ) from exc
+            raise
+        return getattr(module, attr_name)
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/scriptdb/asyncdb.py
+++ b/src/scriptdb/asyncdb.py
@@ -6,7 +6,12 @@ import logging
 import contextlib
 import inspect
 import re
-import aiosqlite
+try:
+    import aiosqlite
+except ImportError as exc:
+    raise ImportError(
+        "aiosqlite is required for async support; install with 'scriptdb[async]'"
+    ) from exc
 from pathlib import Path
 from typing import (
     Any,

--- a/tests/test_module_exports.py
+++ b/tests/test_module_exports.py
@@ -1,0 +1,9 @@
+import importlib
+
+
+def test_all_exports_importable():
+    """Every name in ``scriptdb.__all__`` should be importable."""
+    scriptdb = importlib.import_module("scriptdb")
+    module = __import__("scriptdb", fromlist=scriptdb.__all__)
+    for name in scriptdb.__all__:
+        assert getattr(module, name)

--- a/tests/test_syncdb_without_aiosqlite.py
+++ b/tests/test_syncdb_without_aiosqlite.py
@@ -1,0 +1,30 @@
+import builtins
+import sys
+import pytest
+
+
+def test_syncdb_works_without_aiosqlite(monkeypatch):
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "aiosqlite":
+            raise ImportError("No module named 'aiosqlite'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    for mod in [m for m in list(sys.modules) if m.startswith("scriptdb") or m == "aiosqlite"]:
+        monkeypatch.delitem(sys.modules, mod, raising=False)
+
+    import scriptdb
+
+    from scriptdb import SyncBaseDB
+
+    class DB(SyncBaseDB):
+        def migrations(self):
+            return []
+
+    with DB.open(":memory:") as db:
+        db.execute("SELECT 1")
+
+    with pytest.raises(ImportError):
+        from scriptdb import AsyncBaseDB


### PR DESCRIPTION
## Summary
- raise a clear ImportError when `aiosqlite` isn't available, suggesting installation via `scriptdb[async]`
- defer importing async components so `SyncBaseDB` can be used without `aiosqlite`
- document lazy imports and add regression test ensuring every symbol in `scriptdb.__all__` imports successfully
- bump version to 1.0.2 and record changes in the changelog

## Testing
- `pip install -e .[test]`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac3951ba908324831a9f2a83cdf941