### PR TITLE
Support Path DB paths and document daemonizable aiosqlite

### DIFF
--- a/src/scriptdb/abstractdb.py
+++ b/src/scriptdb/abstractdb.py
@@ -72,10 +72,13 @@ def run_every_queries(queries: int) -> Callable:
 
 
 class AbstractBaseDB(abc.ABC):
-    def __init__(self, db_path: str, auto_create: bool = True, *, use_wal: bool = True) -> None:
-        if not auto_create and not Path(db_path).exists():
+    def __init__(
+        self, db_path: Union[str, Path], auto_create: bool = True, *, use_wal: bool = True
+    ) -> None:
+        path_obj = Path(db_path)
+        if not auto_create and not path_obj.exists():
             raise RuntimeError(f"Database file {db_path} does not exist")
-        self.db_path = db_path
+        self.db_path = str(path_obj)
         self.auto_create = auto_create
         self.use_wal = use_wal
         self.conn: Union[sqlite3.Connection, aiosqlite.Connection, None] = None

--- a/src/scriptdb/asyncdb.py
+++ b/src/scriptdb/asyncdb.py
@@ -124,7 +124,12 @@ class AsyncBaseDB(AbstractBaseDB):
     """
 
     def __init__(
-        self, db_path: str, auto_create: bool = True, *, use_wal: bool = True, daemonize_thread: bool = False
+        self,
+        db_path: Union[str, Path],
+        auto_create: bool = True,
+        *,
+        use_wal: bool = True,
+        daemonize_thread: bool = False,
     ) -> None:
         super().__init__(db_path, auto_create, use_wal=use_wal)
         self.conn: aiosqlite.Connection = cast(aiosqlite.Connection, None)
@@ -150,7 +155,12 @@ class AsyncBaseDB(AbstractBaseDB):
 
     @classmethod
     def open(
-        cls: Type[T], db_path: str, *, auto_create: bool = True, use_wal: bool = True, daemonize_thread: bool = False
+        cls: Type[T],
+        db_path: Union[str, Path],
+        *,
+        auto_create: bool = True,
+        use_wal: bool = True,
+        daemonize_thread: bool = False,
     ) -> _AsyncDBOpenContext[T]:
         """
         Factory returning an awaitable context manager for the database instance.
@@ -160,6 +170,7 @@ class AsyncBaseDB(AbstractBaseDB):
             ``async with YourDB.open("app.db") as db: ...``
 
         Parameters:
+            db_path: Filesystem path to the SQLite database.
             auto_create: Whether to create the database file if it does not exist.
             use_wal: Enable SQLite's WAL journal mode. Pass ``False`` to disable.
             daemonize_thread: Make background thread to be daemonize, set it to True if program hangs on exit
@@ -167,9 +178,10 @@ class AsyncBaseDB(AbstractBaseDB):
         Returns:
             Awaitable context manager yielding an initialized subclass instance of type T.
         """
-        if not auto_create and not Path(db_path).exists():
+        path_obj = Path(db_path)
+        if not auto_create and not path_obj.exists():
             raise RuntimeError(f"Database file {db_path} does not exist")
-        return _AsyncDBOpenContext(cls, db_path, auto_create, use_wal, daemonize_thread)
+        return _AsyncDBOpenContext(cls, str(path_obj), auto_create, use_wal, daemonize_thread)
 
     @abc.abstractmethod
     def migrations(self) -> List[Dict[str, Any]]:

--- a/src/scriptdb/syncdb.py
+++ b/src/scriptdb/syncdb.py
@@ -54,7 +54,9 @@ class _SyncDBOpenContext(Generic[T]):
 
 
 class SyncBaseDB(AbstractBaseDB):
-    def __init__(self, db_path: str, auto_create: bool = True, *, use_wal: bool = True) -> None:
+    def __init__(
+        self, db_path: Union[str, Path], auto_create: bool = True, *, use_wal: bool = True
+    ) -> None:
         super().__init__(db_path, auto_create, use_wal=use_wal)
         self.conn: sqlite3.Connection = cast(sqlite3.Connection, None)
         self._periodic_threads: List[threading.Thread] = []
@@ -62,10 +64,13 @@ class SyncBaseDB(AbstractBaseDB):
         self._upsert_lock = threading.Lock()
 
     @classmethod
-    def open(cls: Type[T], db_path: str, *, auto_create: bool = True, use_wal: bool = True) -> _SyncDBOpenContext[T]:
-        if not auto_create and not Path(db_path).exists():
+    def open(
+        cls: Type[T], db_path: Union[str, Path], *, auto_create: bool = True, use_wal: bool = True
+    ) -> _SyncDBOpenContext[T]:
+        path_obj = Path(db_path)
+        if not auto_create and not path_obj.exists():
             raise RuntimeError(f"Database file {db_path} does not exist")
-        return _SyncDBOpenContext(cls, db_path, auto_create, use_wal)
+        return _SyncDBOpenContext(cls, str(path_obj), auto_create, use_wal)
 
     def init(self) -> None:
         self.conn = sqlite3.connect(self.db_path, check_same_thread=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,12 @@
-# tests/conftest.py
+"""Pytest helpers to detect and handle lingering threads.
+
+The test suite occasionally triggers a long-standing issue in ``aiosqlite``
+where its worker thread keeps running after the event loop finishes. This file
+groups live threads at session end and, if any aiosqlite workers remain,
+prints their stacks and schedules a ``SIGTERM`` to ensure the process exits.
+It helps verify that ``daemonize_thread`` works and prevents hanging tests.
+"""
+
 import sys
 import os
 import time

--- a/tests/test_async_basedb.py
+++ b/tests/test_async_basedb.py
@@ -25,7 +25,7 @@ class MyTestDB(AsyncBaseDB):
 @pytest_asyncio.fixture
 async def db(tmp_path):
     db_file = tmp_path / "test.db"
-    async with MyTestDB.open(str(db_file), daemonize_thread=True) as db:
+    async with MyTestDB.open(db_file, daemonize_thread=True) as db:
         yield db
 
 
@@ -56,7 +56,7 @@ async def test_wal_mode_enabled(db):
 @pytest.mark.asyncio
 async def test_wal_mode_can_be_disabled(tmp_path):
     db_file = tmp_path / "nowal.db"
-    db = await MyTestDB.open(str(db_file), use_wal=False, daemonize_thread=True)
+    db = await MyTestDB.open(db_file, use_wal=False, daemonize_thread=True)
     try:
         mode = await db.query_scalar("PRAGMA journal_mode")
         assert mode != "wal"

--- a/tests/test_sync_basedb.py
+++ b/tests/test_sync_basedb.py
@@ -30,7 +30,7 @@ class MyTestDB(SyncBaseDB):
 @pytest.fixture
 def db(tmp_path):
     db_file = tmp_path / "test.db"
-    with MyTestDB.open(str(db_file)) as db:
+    with MyTestDB.open(db_file) as db:
         yield db
 
 
@@ -57,7 +57,7 @@ def test_wal_mode_enabled(db):
 
 def test_wal_mode_can_be_disabled(tmp_path):
     db_file = tmp_path / "nowal.db"
-    ctx = MyTestDB.open(str(db_file), use_wal=False)
+    ctx = MyTestDB.open(db_file, use_wal=False)
     db = ctx._open()
     try:
         mode = db.query_scalar("PRAGMA journal_mode")


### PR DESCRIPTION
## Summary
- allow AbstractBaseDB, SyncBaseDB and AsyncBaseDB to accept `pathlib.Path` in constructors and open helpers
- document daemonizable_aio­sqlite and show how `daemonize_thread=True` avoids hanging threads
- explain thread monitoring in test `conftest.py`

## Testing
- `ruff check .`
- `mypy src/scriptdb`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae9c525edc8324b4d58765efaa3eb1