### PR TITLE
Add coverage reporting to tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,6 @@ regular Python package.
 
 - Keep changes focused; avoid modifying unrelated files.
 - Install test dependencies with `pip install -e .[test]` before running tests.
-- Run `ruff check .`, `mypy src/scriptdb`, and `pytest` before committing.
+- Run `ruff check .`, `mypy src/scriptdb`, and `pytest --cov=scriptdb --cov-report=term-missing` before committing.
 - The codebase uses the `src/` layout with the package located at `src/scriptdb`.
 

--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ is generated.
 ## Running tests
 
 ```bash
-pytest
+pytest --cov=scriptdb --cov-report=term-missing
 ```
 
 ## Contributing
@@ -387,11 +387,12 @@ source venv/bin/activate
 pip install -e .[async,test]
 ```
 
-Before committing, ensure code passes the linters and type checks:
+Before committing, ensure code passes the linters, type checks, and tests with coverage:
 
 ```bash
 ruff check .
 mypy src/scriptdb
+pytest --cov=scriptdb --cov-report=term-missing
 ```
 
 ## AI Usage disclaimer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ test = [
     "pytest>=7.0",
     "pytest-asyncio>=0.20",
     "aiosqlite>=0.19",
+    "pytest-cov>=4.1",
     "ruff>=0.0.275",
     "mypy>=1.0,<1.11",
 ]


### PR DESCRIPTION
## Summary
- document how to run tests with coverage in README and AGENTS guide
- include pytest-cov in test dependencies for coverage reports

## Testing
- `ruff check .`
- `mypy src/scriptdb`
- `pytest --cov=scriptdb --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68aec0fad9448324a7e47c5ef98f5599