### PR TITLE
Add Makefile for lint/test commands and document usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+.PHONY: help lint test
+.DEFAULT_GOAL := help
+
+help:
+	@echo "Available commands:"
+	@echo "  lint - run ruff and mypy"
+	@echo "  test - run tests with coverage"
+
+lint:
+	ruff check .
+	mypy src/scriptdb
+
+test:
+	pytest --cov=scriptdb --cov-report=term-missing

--- a/README.md
+++ b/README.md
@@ -362,7 +362,13 @@ is generated.
 ## Running tests
 
 ```bash
-pytest --cov=scriptdb --cov-report=term-missing
+make test
+```
+
+Run linters and type checks with:
+
+```bash
+make lint
 ```
 
 ## Contributing
@@ -390,9 +396,8 @@ pip install -e .[async,test]
 Before committing, ensure code passes the linters, type checks, and tests with coverage:
 
 ```bash
-ruff check .
-mypy src/scriptdb
-pytest --cov=scriptdb --cov-report=term-missing
+make lint
+make test
 ```
 
 ## AI Usage disclaimer

--- a/tests/test_daemonizable_aiosqlite.py
+++ b/tests/test_daemonizable_aiosqlite.py
@@ -1,0 +1,30 @@
+import asyncio
+from scriptdb import daemonizable_aiosqlite as dai
+
+
+def test_connect_with_loop_triggers_warning(monkeypatch):
+    calls = []
+    monkeypatch.setattr(dai.logger, "warning", lambda *a, **k: calls.append((a, k)))
+    loop = asyncio.new_event_loop()
+    try:
+        conn = dai.connect(b":memory:", loop=loop)
+        loop.run_until_complete(conn.__aenter__())
+        assert isinstance(conn, dai.DaemonConnection)
+        assert calls
+        loop.run_until_complete(conn.close())
+    finally:
+        loop.close()
+
+
+def test_connect_accepts_path(tmp_path):
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        db_path = tmp_path / "test.db"
+        conn = dai.connect(db_path)
+        loop.run_until_complete(conn.__aenter__())
+        assert isinstance(conn, dai.DaemonConnection)
+        loop.run_until_complete(conn.close())
+    finally:
+        loop.close()
+        asyncio.set_event_loop(None)


### PR DESCRIPTION
## Summary
- add Makefile targets for linting (ruff, mypy) and testing with coverage
- document `make lint` and `make test` usage in README

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68aeeedcfe80832499caaaa28a3fa5bf