### PR TITLE
feat: improve builder usability

### DIFF
--- a/src/scriptdb/__init__.pyi
+++ b/src/scriptdb/__init__.pyi
@@ -1,0 +1,20 @@
+from .abstractdb import AbstractBaseDB, run_every_seconds, run_every_queries
+from .dbbuilder import Builder
+from .syncdb import SyncBaseDB
+from .asyncdb import AsyncBaseDB
+from .asynccachedb import AsyncCacheDB
+from .synccachedb import SyncCacheDB
+
+__all__ = [
+    "AbstractBaseDB",
+    "AsyncBaseDB",
+    "SyncBaseDB",
+    "Builder",
+    "run_every_seconds",
+    "run_every_queries",
+    "AsyncCacheDB",
+    "SyncCacheDB",
+    "__version__",
+]
+
+__version__: str


### PR DESCRIPTION
## Summary
- expose AsyncBaseDB and cache classes via a PEP 561 stub so IDEs can resolve their members
- allow Builder instances in migrations and give them a common base with `__str__`
- `drop_table` now returns SQL directly and docs show using `str()` or `.done()`
- run `sqls` migrations inside a transaction and test rollback on failure
- ensure `sqls` migrations roll back even on interrupts by catching `BaseException`

## Testing
- `ruff check .`
- `mypy src/scriptdb`
- `pytest --cov=scriptdb --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68b95d5bc66c8324a02bae7d18cf56f2