### PR TITLE
fix: remove duplicate query hook call

### DIFF
--- a/src/scriptdb/syncdb.py
+++ b/src/scriptdb/syncdb.py
@@ -297,7 +297,6 @@ class SyncBaseDB(AbstractBaseDB):
                         self.conn.execute(update_sql, row)
             self.conn.commit()
             self._on_query()
-        self._on_query()
 
     @require_init
     def delete_one(self, table: str, pk: Any) -> int:


### PR DESCRIPTION
## Summary
- ensure `SyncBaseDB.upsert_many` triggers query hooks exactly once per call

## Testing
- `ruff check .`
- `mypy src/scriptdb`
- `pytest --cov=scriptdb --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68ba97d2df608324ad82e6b0ad1719d3