### PR TITLE
Handle empty row in update_one

### DIFF
--- a/src/scriptdb/syncdb.py
+++ b/src/scriptdb/syncdb.py
@@ -324,6 +324,8 @@ class SyncBaseDB(AbstractBaseDB):
 
     @require_init
     def update_one(self, table: str, pk: Any, row: Dict[str, Any]) -> int:
+        if not row:
+            return 0
         pk_col = self._primary_key(table)
         assignments = ", ".join([f"{c}=:{c}" for c in row])
         sql = f"UPDATE {table} SET {assignments} WHERE {pk_col}=:pk"

--- a/tests/test_sync_basedb.py
+++ b/tests/test_sync_basedb.py
@@ -200,6 +200,14 @@ def test_update_one(db):
     assert row["x"] == 5
 
 
+def test_update_one_empty_dict(db):
+    pk = db.insert_one("t", {"x": 1})
+    updated = db.update_one("t", pk, {})
+    assert updated == 0
+    row = db.query_one("SELECT x FROM t WHERE id=?", (pk,))
+    assert row["x"] == 1
+
+
 def test_query_many_gen(db):
     db.execute_many("INSERT INTO t(x) VALUES(?)", [(1,), (2,), (3,)])
     results = []


### PR DESCRIPTION
## Summary
- avoid SQL execution when `update_one` receives an empty row
- test that updating with an empty dict returns 0

## Testing
- `ruff check .`
- `mypy src/scriptdb`
- `pytest --cov=scriptdb --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68ba97df71448324b4eb5a59dafe5a6a