### PR TITLE
Handle PK-only upserts

### DIFF
--- a/src/scriptdb/syncdb.py
+++ b/src/scriptdb/syncdb.py
@@ -271,6 +271,8 @@ class SyncBaseDB(AbstractBaseDB):
                 if update_sql:
                     self.conn.execute(update_sql, row)
                 else:
+                    self.conn.rollback()
+                    self._on_query()
                     return row[pk_col]
             self.conn.commit()
             self._on_query()

--- a/tests/test_sync_basedb.py
+++ b/tests/test_sync_basedb.py
@@ -159,6 +159,16 @@ def test_upsert_one_without_pk(db):
     assert row["x"] == 1
 
 
+def test_upsert_one_pk_only_twice(db):
+    pk = db.upsert_one("t", {"id": 1})
+    assert pk == 1
+    pk_again = db.upsert_one("t", {"id": 1})
+    assert pk_again == 1
+    row = db.query_one("SELECT id, x FROM t WHERE id=1")
+    assert row["id"] == 1
+    assert row["x"] is None
+
+
 def test_upsert_many(db):
     db.upsert_many("t", [{"id": 1, "x": 1}, {"id": 2, "x": 2}])
     db.upsert_many("t", [{"id": 1, "x": 10}, {"id": 3, "x": 3}])


### PR DESCRIPTION
## Summary
- ensure `upsert_one` rolls back and fires query hook when only PK is provided
- test inserting a row with just the primary key twice

## Testing
- `ruff check .`
- `mypy src/scriptdb`
- `pytest --cov=scriptdb --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68ba97eef73c8324ada32dfd36e88393