### PR TITLE
Use warnings for deprecated loop parameter

### DIFF
--- a/src/scriptdb/daemonizable_aiosqlite.py
+++ b/src/scriptdb/daemonizable_aiosqlite.py
@@ -1,12 +1,10 @@
 import asyncio
 import sqlite3
+import warnings
 from pathlib import Path
-from typing import Callable, Optional, Union, Any
+from typing import Any, Callable, Optional, Union
 
 from aiosqlite import Connection
-from logging import getLogger
-
-logger = getLogger(__name__)
 
 
 """
@@ -45,9 +43,10 @@ def connect(
     """Create and return a connection proxy to the sqlite database."""
 
     if loop is not None:
-        logger.warning(
+        warnings.warn(
             "aiosqlite.connect() no longer uses the `loop` parameter",
             DeprecationWarning,
+            stacklevel=2,
         )
 
     def connector() -> sqlite3.Connection:

--- a/tests/test_daemonizable_aiosqlite.py
+++ b/tests/test_daemonizable_aiosqlite.py
@@ -1,17 +1,16 @@
 import asyncio
+import pytest
 from scriptdb import daemonizable_aiosqlite as dai
 
 
-def test_connect_with_loop_triggers_warning(monkeypatch):
-    calls = []
-    monkeypatch.setattr(dai.logger, "warning", lambda *a, **k: calls.append((a, k)))
+def test_connect_with_loop_triggers_warning():
     loop = asyncio.new_event_loop()
     try:
-        conn = dai.connect(b":memory:", loop=loop)
-        loop.run_until_complete(conn.__aenter__())
-        assert isinstance(conn, dai.DaemonConnection)
-        assert calls
-        loop.run_until_complete(conn.close())
+        with pytest.warns(DeprecationWarning):
+            conn = dai.connect(b":memory:", loop=loop)
+            loop.run_until_complete(conn.__aenter__())
+            assert isinstance(conn, dai.DaemonConnection)
+            loop.run_until_complete(conn.close())
     finally:
         loop.close()
 


### PR DESCRIPTION
## Summary
- replace logger-based warning with `warnings.warn`
- cover deprecated loop parameter with warning-based test

## Testing
- `ruff check .`
- `mypy src/scriptdb`
- `pytest --cov=scriptdb --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68ba980e1a20832486800069b041dd1a