### PR TITLE
Add tests for update_one with empty data

### DIFF
--- a/src/scriptdb/syncdb.py
+++ b/src/scriptdb/syncdb.py
@@ -324,6 +324,8 @@ class SyncBaseDB(AbstractBaseDB):
 
     @require_init
     def update_one(self, table: str, pk: Any, row: Dict[str, Any]) -> int:
+        if not row:
+            return 0
         pk_col = self._primary_key(table)
         assignments = ", ".join([f"{c}=:{c}" for c in row])
         sql = f"UPDATE {table} SET {assignments} WHERE {pk_col}=:pk"

--- a/tests/test_async_basedb.py
+++ b/tests/test_async_basedb.py
@@ -211,6 +211,15 @@ async def test_update_one(db):
 
 
 @pytest.mark.asyncio
+async def test_update_one_empty_dict(db):
+    pk = await db.insert_one("t", {"x": 1})
+    updated = await db.update_one("t", pk, {})
+    assert updated == 0
+    row = await db.query_one("SELECT x FROM t WHERE id=?", (pk,))
+    assert row["x"] == 1
+
+
+@pytest.mark.asyncio
 async def test_query_many_gen(db):
     await db.execute_many("INSERT INTO t(x) VALUES(?)", [(1,), (2,), (3,)])
     results = []

--- a/tests/test_sync_basedb.py
+++ b/tests/test_sync_basedb.py
@@ -200,6 +200,14 @@ def test_update_one(db):
     assert row["x"] == 5
 
 
+def test_update_one_empty_dict(db):
+    pk = db.insert_one("t", {"x": 1})
+    updated = db.update_one("t", pk, {})
+    assert updated == 0
+    row = db.query_one("SELECT x FROM t WHERE id=?", (pk,))
+    assert row["x"] == 1
+
+
 def test_query_many_gen(db):
     db.execute_many("INSERT INTO t(x) VALUES(?)", [(1,), (2,), (3,)])
     results = []


### PR DESCRIPTION
## Summary
- add tests for calling `update_one` with an empty dict in async and sync DB tests
- handle empty `update_one` inputs in `SyncBaseDB`

## Testing
- `ruff check .`
- `mypy src/scriptdb`
- `pytest --cov=scriptdb --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68ba98155a948324ab580a1e43a462b6