### PR TITLE
Add tests for upserting rows with only a primary key

### DIFF
--- a/tests/test_async_basedb.py
+++ b/tests/test_async_basedb.py
@@ -168,6 +168,17 @@ async def test_upsert_one_without_pk(db):
 
 
 @pytest.mark.asyncio
+async def test_upsert_one_only_pk(db):
+    pk = await db.upsert_one("t", {"id": 1})
+    assert pk == 1
+    pk = await db.upsert_one("t", {"id": 1})
+    assert pk == 1
+    row = await db.query_one("SELECT id, x FROM t WHERE id=?", (1,))
+    assert row["id"] == 1
+    assert row["x"] is None
+
+
+@pytest.mark.asyncio
 async def test_upsert_many(db):
     await db.upsert_many("t", [{"id": 1, "x": 1}, {"id": 2, "x": 2}])
     await db.upsert_many("t", [{"id": 1, "x": 10}, {"id": 3, "x": 3}])

--- a/tests/test_sync_basedb.py
+++ b/tests/test_sync_basedb.py
@@ -159,6 +159,16 @@ def test_upsert_one_without_pk(db):
     assert row["x"] == 1
 
 
+def test_upsert_one_only_pk(db):
+    pk = db.upsert_one("t", {"id": 1})
+    assert pk == 1
+    pk = db.upsert_one("t", {"id": 1})
+    assert pk == 1
+    row = db.query_one("SELECT id, x FROM t WHERE id=?", (1,))
+    assert row["id"] == 1
+    assert row["x"] is None
+
+
 def test_upsert_many(db):
     db.upsert_many("t", [{"id": 1, "x": 1}, {"id": 2, "x": 2}])
     db.upsert_many("t", [{"id": 1, "x": 10}, {"id": 3, "x": 3}])


### PR DESCRIPTION
## Summary
- verify SyncBaseDB.upsert_one returns PK when called with only primary key
- add matching test for AsyncBaseDB.upsert_one

## Testing
- `ruff check .`
- `mypy src/scriptdb`
- `pytest --cov=scriptdb --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68ba983b64d0832482a75f4d87234228