### PR TITLE
Ensure insert_many handles empty rows

### DIFF
--- a/tests/test_async_basedb.py
+++ b/tests/test_async_basedb.py
@@ -132,6 +132,13 @@ async def test_insert_many(db):
 
 
 @pytest.mark.asyncio
+async def test_insert_many_empty(db):
+    await db.insert_many("t", [])
+    count = await db.query_scalar("SELECT COUNT(*) FROM t")
+    assert count == 0
+
+
+@pytest.mark.asyncio
 async def test_delete_one(db):
     pk = await db.insert_one("t", {"x": 1})
     deleted = await db.delete_one("t", pk)

--- a/tests/test_sync_basedb.py
+++ b/tests/test_sync_basedb.py
@@ -127,6 +127,12 @@ def test_insert_many(db):
     assert [r["x"] for r in rows] == [1, 2]
 
 
+def test_insert_many_empty(db):
+    db.insert_many("t", [])
+    count = db.query_scalar("SELECT COUNT(*) FROM t")
+    assert count == 0
+
+
 def test_delete_one(db):
     pk = db.insert_one("t", {"x": 1})
     deleted = db.delete_one("t", pk)


### PR DESCRIPTION
## Summary
- add async and sync tests to confirm `insert_many("t", [])` is a no-op

## Testing
- `ruff check .`
- `mypy src/scriptdb`
- `pytest --cov=scriptdb --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68ba983596a88324b3ee3ae7f54df10b