### PR TITLE
test: ensure keys ignore zero expiry

### DIFF
--- a/tests/test_async_cachedb.py
+++ b/tests/test_async_cachedb.py
@@ -41,6 +41,12 @@ async def test_is_set(db):
 
 
 @pytest.mark.asyncio
+async def test_keys_ignores_zero_expire(db):
+    await db.set("temp", 1, expire_sec=0)
+    assert await db.keys("*") == []
+
+
+@pytest.mark.asyncio
 async def test_del_many_keys_clear(db):
     await db.set("a_1", 1, 60)
     await db.set("a_2", 2, 60)

--- a/tests/test_sync_cachedb.py
+++ b/tests/test_sync_cachedb.py
@@ -36,6 +36,11 @@ def test_is_set(db):
     assert db.is_set("b") is False
 
 
+def test_keys_ignores_zero_expire(db):
+    db.set("temp", 1, expire_sec=0)
+    assert db.keys("*") == []
+
+
 def test_del_many_keys_clear(db):
     db.set("a_1", 1, 60)
     db.set("a_2", 2, 60)


### PR DESCRIPTION
## Summary
- add tests verifying that keys(`*`) excludes entries with expire_sec=0 in both async and sync cache DBs

## Testing
- `ruff check .`
- `mypy src/scriptdb`
- `pytest --cov=scriptdb --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68ba982775488324844bc8adc3be5adb