### PR TITLE
Add tests for callable key/value query_dict

### DIFF
--- a/tests/test_async_basedb.py
+++ b/tests/test_async_basedb.py
@@ -268,6 +268,17 @@ async def test_query_dict(db):
 
 
 @pytest.mark.asyncio
+async def test_query_dict_key_value_callables(db):
+    await db.execute_many("INSERT INTO t(x) VALUES(?)", [(1,), (2,)])
+    result = await db.query_dict(
+        "SELECT id, x FROM t",
+        key=lambda row: row["id"],
+        value=lambda row: row["x"],
+    )
+    assert result == {1: 1, 2: 2}
+
+
+@pytest.mark.asyncio
 async def test_query_dict_requires_key_when_table_unknown(db):
     with pytest.raises(ValueError) as exc:
         await db.query_dict("SELECT 1")

--- a/tests/test_sync_basedb.py
+++ b/tests/test_sync_basedb.py
@@ -252,6 +252,16 @@ def test_query_dict(db):
     assert set(quoted.keys()) == {1, 2}
 
 
+def test_query_dict_key_value_callables(db):
+    db.execute_many("INSERT INTO t(x) VALUES(?)", [(1,), (2,)])
+    result = db.query_dict(
+        "SELECT id, x FROM t",
+        key=lambda row: row["id"],
+        value=lambda row: row["x"],
+    )
+    assert result == {1: 1, 2: 2}
+
+
 def test_query_dict_requires_key_when_table_unknown(db):
     with pytest.raises(ValueError) as exc:
         db.query_dict("SELECT 1")


### PR DESCRIPTION
## Summary
- add async test for `query_dict` accepting callables for both key and value
- add sync test for `query_dict` callables ensuring correct mapping

## Testing
- `ruff check .`
- `python -m mypy src/scriptdb`
- `pytest --cov=scriptdb --cov-report=term-missing`

------
https://chatgpt.com/codex/tasks/task_e_68ba981c74648324813ab6120798d5f4