### PR TITLE
chore: prepare 1.0.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog of the ScriptDB
 
+## 1.0.7 - Expanded tests and reliability fixes
+
+- Added tests for insert_many, query_dict edge cases, zero-expiry keys and PK-only upserts
+- Improved update/upsert handling for empty data and removed duplicate query hooks
+- Introduced DB builder module, unified DDL builder API and added identifier injection tests
+- Replaced deprecated loop parameter warnings and enabled migration rollback on interrupts
+
 ## 1.0.6 - Added simple SQL DDL queries builder
 
 - Added handy SQL DDL queries building tools

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scriptdb"
-version = "1.0.6"
+version = "1.0.7"
 description = "Simple SQLite sync/async wrapper with migration support for use in ad-hoc scripts"
 readme = "README.md"
 license = {file = "LICENSE"}


### PR DESCRIPTION
## Summary
- document changes since 1.0.6 and bump to 1.0.7

## Testing
- `ruff check .`
- `mypy src/scriptdb`
- `pytest --cov=scriptdb --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68baa4db6ec483249497259571eebafa