### PR TITLE
Adjust periodic task logging to debug level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog of the ScriptDB
 
+## 1.0.8 - Reduce routine logging noise
+
+- Lowered periodic task lifecycle logging in `AsyncBaseDB` and `SyncBaseDB` from INFO to DEBUG
+
 ## 1.0.7 - Expanded tests and reliability fixes
 
 - Added tests for insert_many, query_dict edge cases, zero-expiry keys and PK-only upserts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scriptdb"
-version = "1.0.7"
+version = "1.0.8"
 description = "Simple SQLite sync/async wrapper with migration support for use in ad-hoc scripts"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/scriptdb/asyncdb.py
+++ b/src/scriptdb/asyncdb.py
@@ -217,9 +217,9 @@ class AsyncBaseDB(AbstractBaseDB):
 
             async def runner(method=method, seconds=seconds):
                 while True:
-                    logger.info("Launching method %s", method.__name__)
+                    logger.debug("Launching method %s", method.__name__)
                     await method()
-                    logger.info(
+                    logger.debug(
                         "Method %s finished, next run in %s seconds",
                         method.__name__,
                         seconds,
@@ -340,9 +340,9 @@ class AsyncBaseDB(AbstractBaseDB):
                 hook["count"] = 0
 
                 async def runner(method=hook["method"], interval=hook["interval"]):
-                    logger.info("Launching method %s", method.__name__)
+                    logger.debug("Launching method %s", method.__name__)
                     await method()
-                    logger.info(
+                    logger.debug(
                         "Method %s finished, next run after %s queries",
                         method.__name__,
                         interval,

--- a/src/scriptdb/syncdb.py
+++ b/src/scriptdb/syncdb.py
@@ -87,9 +87,9 @@ class SyncBaseDB(AbstractBaseDB):
 
             def runner(method=method, seconds=seconds):
                 while not self._stop_event.wait(seconds):
-                    logger.info("Launching method %s", method.__name__)
+                    logger.debug("Launching method %s", method.__name__)
                     method()
-                    logger.info(
+                    logger.debug(
                         "Method %s finished, next run in %s seconds",
                         method.__name__,
                         seconds,
@@ -195,7 +195,7 @@ class SyncBaseDB(AbstractBaseDB):
             hook["count"] += 1
             if hook["count"] >= hook["interval"]:
                 hook["count"] = 0
-                logger.info("Launching method %s", hook["method"].__name__)
+                logger.debug("Launching method %s", hook["method"].__name__)
                 hook["method"]()
 
     @require_init


### PR DESCRIPTION
## Summary
- lower periodic task lifecycle logging in both AsyncBaseDB and SyncBaseDB from INFO to DEBUG to reduce log noise

## Testing
- ruff check .
- mypy src/scriptdb
- pytest --cov=scriptdb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e5fc4bc08c832482495409414c6531