### PR TITLE
Guard RAM index helpers when caching is disabled

### DIFF
--- a/src/scriptdb/_cache_index.py
+++ b/src/scriptdb/_cache_index.py
@@ -1,0 +1,205 @@
+"""Shared helpers for cache databases that track keys in RAM."""
+from __future__ import annotations
+
+from bisect import bisect_left
+from datetime import datetime, timezone
+from functools import wraps
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple, cast
+
+import logging
+import threading
+from sys import getsizeof
+
+
+logger = logging.getLogger(__name__)
+
+
+def _ram_locked(method):
+    """Decorator that guards cache-index mutations with ``_ram_lock``."""
+
+    @wraps(method)
+    def wrapper(self, *args, **kwargs):  # type: ignore[override]
+        if not getattr(self, "_cache_keys_in_ram", False):
+            return method(self, *args, **kwargs)
+        with self._ram_lock:
+            return method(self, *args, **kwargs)
+
+    return wrapper
+
+
+class _CacheKeyIndexMixin:
+    """Mixin that manages an in-memory index of cache keys and expirations."""
+
+    _MISSING = object()
+
+    def __init__(self, *args, cache_keys_in_ram: bool = False, **kwargs) -> None:
+        """Initialize RAM-index storage; subclasses forward ``cache_keys_in_ram``."""
+        self._cache_keys_in_ram = cache_keys_in_ram
+        self._ram_lock = threading.Lock()
+        self._ram_keys: Dict[str, Optional[datetime]] = {}
+        self._ram_entries: List[Tuple[str, Optional[datetime]]] = []
+        self._ram_scores: List[float] = []
+        super().__init__(*args, **kwargs)
+
+    @staticmethod
+    def _parse_expire(value: Optional[str]) -> Optional[datetime]:
+        """Convert an ISO timestamp to ``datetime`` for RAM bookkeeping."""
+        return datetime.fromisoformat(value) if value else None
+
+    @staticmethod
+    def _expire_score(expire: Optional[datetime]) -> float:
+        """Return ordering value for expires; used internally for sorting."""
+        return expire.timestamp() if expire is not None else float("inf")
+
+    def _reload_ram_index(self, rows: Iterable[Mapping[str, Any]]) -> None:
+        """Rebuild the RAM index from DB rows; call from subclass initialization."""
+        if not self._cache_keys_in_ram:
+            return
+        now = datetime.now(timezone.utc)
+        mapping: Dict[str, Optional[datetime]] = {}
+        entries: List[Tuple[str, Optional[datetime]]] = []
+        for row in rows:
+            key = str(row["key"])
+            expire = self._parse_expire(cast(Optional[str], row["expire_utc"]))
+            if expire is not None and expire <= now:
+                continue
+            mapping[key] = expire
+            entries.append((key, expire))
+        entries.sort(key=lambda item: self._expire_score(item[1]), reverse=True)
+        scores = [-self._expire_score(expire) for _, expire in entries]
+        self._ram_reset(mapping, entries, scores)
+        if logger.isEnabledFor(logging.DEBUG):
+            size = getsizeof(mapping) + getsizeof(entries) + getsizeof(scores)
+            size += sum(getsizeof(key) + getsizeof(expire) for key, expire in mapping.items())
+            size += sum(
+                getsizeof(entry) + getsizeof(entry[0]) + getsizeof(entry[1])
+                for entry in entries
+            )
+            size += sum(getsizeof(score) for score in scores)
+            logger.debug(
+                "Reloaded RAM cache index with %d keys (~%.1f KiB)",
+                len(entries),
+                size / 1024,
+            )
+
+    @_ram_locked
+    def _ram_reset(
+        self,
+        mapping: Dict[str, Optional[datetime]],
+        entries: List[Tuple[str, Optional[datetime]]],
+        scores: List[float],
+    ) -> None:
+        """Replace RAM index containers; call only from mixin helpers."""
+        if not self._cache_keys_in_ram:
+            return
+        self._ram_keys = mapping
+        self._ram_entries = entries
+        self._ram_scores = scores
+
+    @_ram_locked
+    def _ram_has_key(self, key: str, now: datetime) -> Optional[bool]:
+        """Check RAM index for ``key``; call from cache ``get``/``is_set`` methods."""
+        if not self._cache_keys_in_ram:
+            return None
+        stored = self._ram_keys.get(key, self._MISSING)
+        if stored is self._MISSING:
+            return False
+        expire = cast(Optional[datetime], stored)
+        if expire is not None and expire <= now:
+            self._ram_remove_entry_unlocked(key)
+            return False
+        return True
+
+    @_ram_locked
+    def _ram_mark_miss(self, key: str) -> None:
+        """Remove stale ``key`` after cache miss; call from cache ``get`` paths."""
+        if not self._cache_keys_in_ram:
+            return
+        self._ram_remove_entry_unlocked(key)
+
+    @_ram_locked
+    def _ram_on_set(self, key: str, expire: Optional[datetime], now: datetime) -> None:
+        """Update RAM structures after ``set``; invoked by cache ``set`` implementations."""
+        if not self._cache_keys_in_ram:
+            return
+        self._ram_purge_expired_unlocked(now)
+        self._ram_remove_entry_unlocked(key)
+        if expire is None or expire > now:
+            self._ram_insert_unlocked(key, expire)
+
+    @_ram_locked
+    def _ram_on_delete(self, key: str, now: datetime) -> None:
+        """Update RAM structures after ``delete``; invoked by cache ``delete`` methods."""
+        if not self._cache_keys_in_ram:
+            return
+        self._ram_purge_expired_unlocked(now)
+        self._ram_remove_entry_unlocked(key)
+
+    @_ram_locked
+    def _ram_on_del_many(self, keys: Sequence[str], now: datetime) -> None:
+        """Update RAM structures after bulk delete; call from cache ``del_many``."""
+        if not self._cache_keys_in_ram:
+            return
+        self._ram_purge_expired_unlocked(now)
+        for key in keys:
+            self._ram_remove_entry_unlocked(key)
+
+    @_ram_locked
+    def _ram_on_clear(self) -> None:
+        """Clear RAM index entirely; call from cache ``clear`` implementations."""
+        if not self._cache_keys_in_ram:
+            return
+        self._ram_keys.clear()
+        self._ram_entries.clear()
+        self._ram_scores.clear()
+
+    @_ram_locked
+    def _ram_purge_expired(self, now: datetime) -> None:
+        """Remove expired entries; call from cache maintenance hooks (e.g. cleanup)."""
+        if not self._cache_keys_in_ram:
+            return
+        self._ram_purge_expired_unlocked(now)
+
+    def _ram_insert_unlocked(self, key: str, expire: Optional[datetime]) -> None:
+        """Insert entry without locking; caller must hold ``_ram_lock``."""
+        if not self._cache_keys_in_ram:
+            return
+        score = self._expire_score(expire)
+        neg_score = -score
+        idx = bisect_left(self._ram_scores, neg_score)
+        self._ram_scores.insert(idx, neg_score)
+        self._ram_entries.insert(idx, (key, expire))
+        self._ram_keys[key] = expire
+
+    def _ram_remove_entry_unlocked(self, key: str) -> None:
+        """Remove entry without locking; caller must hold ``_ram_lock``."""
+        if not self._cache_keys_in_ram:
+            return
+        stored = self._ram_keys.pop(key, self._MISSING)
+        if stored is self._MISSING:
+            return
+        expire = cast(Optional[datetime], stored)
+        neg_score = -self._expire_score(expire)
+        idx = bisect_left(self._ram_scores, neg_score)
+        while idx < len(self._ram_scores) and self._ram_scores[idx] == neg_score:
+            entry_key, _ = self._ram_entries[idx]
+            if entry_key == key:
+                del self._ram_entries[idx]
+                del self._ram_scores[idx]
+                break
+            idx += 1
+
+    def _ram_purge_expired_unlocked(self, now: datetime) -> None:
+        """Delete expired entries without locking; caller must hold ``_ram_lock``."""
+        if not self._cache_keys_in_ram:
+            return
+        if not self._ram_scores:
+            return
+        neg_now = -now.timestamp()
+        cutoff = bisect_left(self._ram_scores, neg_now)
+        if cutoff >= len(self._ram_entries):
+            return
+        for key, _ in self._ram_entries[cutoff:]:
+            self._ram_keys.pop(key, None)
+        del self._ram_entries[cutoff:]
+        del self._ram_scores[cutoff:]

--- a/src/scriptdb/asynccachedb.py
+++ b/src/scriptdb/asynccachedb.py
@@ -4,14 +4,61 @@ import inspect
 import pickle
 import sqlite3
 from datetime import datetime, timedelta, timezone
-from typing import Any, Callable, List, Optional
+from pathlib import Path
+from typing import Any, Callable, List, Optional, Union
 
+from ._cache_index import _CacheKeyIndexMixin
 from .abstractdb import run_every_seconds, require_init
-from .asyncdb import AsyncBaseDB
+from .asyncdb import AsyncBaseDB, _AsyncDBOpenContext
 
 
-class AsyncCacheDB(AsyncBaseDB):
-    """SQLite-backed cache database with expiration support."""
+class AsyncCacheDB(_CacheKeyIndexMixin, AsyncBaseDB):
+    """SQLite-backed cache database with optional in-memory key index."""
+
+    def __init__(
+        self,
+        db_path: Union[str, Path],
+        auto_create: bool = True,
+        *,
+        use_wal: bool = True,
+        daemonize_thread: bool = False,
+        cache_keys_in_ram: bool = False,
+    ) -> None:
+        super().__init__(
+            db_path,
+            auto_create,
+            use_wal=use_wal,
+            daemonize_thread=daemonize_thread,
+            cache_keys_in_ram=cache_keys_in_ram,
+        )
+
+    @classmethod
+    def open(
+        cls,
+        db_path: Union[str, Path],
+        *,
+        auto_create: bool = True,
+        use_wal: bool = True,
+        daemonize_thread: bool = False,
+        cache_keys_in_ram: bool = False,
+    ) -> "_AsyncCacheDBOpenContext":
+        path_obj = Path(db_path)
+        if not auto_create and not path_obj.exists():
+            raise RuntimeError(f"Database file {db_path} does not exist")
+        return _AsyncCacheDBOpenContext(
+            cls,
+            str(path_obj),
+            auto_create,
+            use_wal,
+            daemonize_thread,
+            cache_keys_in_ram,
+        )
+
+    async def init(self) -> None:
+        await super().init()
+        if self._cache_keys_in_ram:
+            rows = await self.query_many("SELECT key, expire_utc FROM cache")
+            self._reload_ram_index(rows)
 
     def migrations(self):
         return [
@@ -25,18 +72,27 @@ class AsyncCacheDB(AsyncBaseDB):
 
     @require_init
     async def get(self, key: str, default: Any = None) -> Any:
+        now = datetime.now(timezone.utc)
+        cached_presence = self._ram_has_key(key, now)
+        if cached_presence is False:
+            return default
         row = await self.query_one("SELECT value, expire_utc FROM cache WHERE key=?", (key,))
         if row is None:
+            self._ram_mark_miss(key)
             return default
         expire_utc = row["expire_utc"]
         if expire_utc is not None:
-            if datetime.fromisoformat(expire_utc) <= datetime.now(timezone.utc):
+            expire_dt = datetime.fromisoformat(expire_utc)
+            if expire_dt <= now:
+                self._ram_mark_miss(key)
                 return default
         return pickle.loads(row["value"])
 
     @require_init
     async def is_set(self, key: str) -> bool:
-        """Return ``True`` if ``key`` exists and is not expired."""
+        cached_presence = self._ram_has_key(key, datetime.now(timezone.utc))
+        if cached_presence is not None:
+            return cached_presence
         exists = await self.query_scalar(
             "SELECT 1 FROM cache WHERE key=? AND (expire_utc IS NULL OR expire_utc > ?)",
             (key, datetime.now(timezone.utc).isoformat()),
@@ -47,28 +103,42 @@ class AsyncCacheDB(AsyncBaseDB):
     async def set(self, key: str, value: Any, expire_sec: Optional[int] = None) -> None:
         now = datetime.now(timezone.utc)
         if expire_sec is None:
-            expire_utc = None
+            expire_dt: Optional[datetime] = None
         elif expire_sec > 0:
-            expire_utc = now + timedelta(seconds=expire_sec)
+            expire_dt = now + timedelta(seconds=expire_sec)
         else:
-            expire_utc = now
+            expire_dt = now
         blob = sqlite3.Binary(pickle.dumps(value))
         row = {
             "key": key,
             "value": blob,
-            "expire_utc": expire_utc.isoformat() if expire_utc else None,
+            "expire_utc": expire_dt.isoformat() if expire_dt else None,
         }
         await self.upsert_one("cache", row)
+        self._ram_on_set(key, expire_dt, now)
 
     @require_init
     async def delete(self, key: str) -> int:
+        now = datetime.now(timezone.utc)
         cur = await self.execute("DELETE FROM cache WHERE key=?", (key,))
+        self._ram_on_delete(key, now)
         return cur.rowcount
 
     @require_init
     async def del_many(self, key_mask: str) -> int:
         pattern = key_mask.replace("_", "\\_").replace("*", "%")
+        keys_to_remove: List[str] = []
+        if self._cache_keys_in_ram:
+            keys_to_remove = [
+                str(key)
+                for key in await self.query_column(
+                    "SELECT key FROM cache WHERE key LIKE ? ESCAPE '\\'",
+                    (pattern,),
+                )
+            ]
         cur = await self.execute("DELETE FROM cache WHERE key LIKE ? ESCAPE '\\'", (pattern,))
+        if self._cache_keys_in_ram:
+            self._ram_on_del_many(keys_to_remove, datetime.now(timezone.utc))
         return cur.rowcount
 
     @require_init
@@ -82,6 +152,7 @@ class AsyncCacheDB(AsyncBaseDB):
     @require_init
     async def clear(self) -> int:
         cur = await self.execute("DELETE FROM cache")
+        self._ram_on_clear()
         return cur.rowcount
 
     def cache(
@@ -110,9 +181,36 @@ class AsyncCacheDB(AsyncBaseDB):
     @run_every_seconds(5)
     @require_init
     async def _cleanup(self) -> None:
+        now = datetime.now(timezone.utc)
         await self.execute(
             "DELETE FROM cache WHERE expire_utc IS NOT NULL AND expire_utc <= ?",
-            (datetime.now(timezone.utc).isoformat(),),
+            (now.isoformat(),),
         )
+        self._ram_purge_expired(now)
 
 
+class _AsyncCacheDBOpenContext(_AsyncDBOpenContext["AsyncCacheDB"]):
+    def __init__(
+        self,
+        cls,
+        db_path: str,
+        auto_create: bool,
+        use_wal: bool,
+        daemonize_thread: bool,
+        cache_keys_in_ram: bool,
+    ) -> None:
+        super().__init__(cls, db_path, auto_create, use_wal, daemonize_thread)
+        self._cache_keys_in_ram = cache_keys_in_ram
+
+    async def _open(self) -> "AsyncCacheDB":
+        instance: AsyncCacheDB = self._cls(  # type: ignore[call-arg]
+            self._db_path,
+            auto_create=self._auto_create,
+            use_wal=self._use_wal,
+            daemonize_thread=self._daemonize_thread,
+            cache_keys_in_ram=self._cache_keys_in_ram,
+        )
+        await instance.init()
+        instance._register_signal_handlers()
+        self._db = instance
+        return instance

--- a/src/scriptdb/synccachedb.py
+++ b/src/scriptdb/synccachedb.py
@@ -5,14 +5,57 @@ import inspect
 import pickle
 import sqlite3
 from datetime import datetime, timedelta, timezone
-from typing import Any, Callable, List, Optional
+from pathlib import Path
+from typing import Any, Callable, List, Optional, Union
 
+from ._cache_index import _CacheKeyIndexMixin
 from .abstractdb import run_every_seconds, require_init
-from .syncdb import SyncBaseDB
+from .syncdb import SyncBaseDB, _SyncDBOpenContext
 
 
-class SyncCacheDB(SyncBaseDB):
-    """Synchronous cache database with expiration support."""
+class SyncCacheDB(_CacheKeyIndexMixin, SyncBaseDB):
+    """Synchronous cache database with optional in-memory key index."""
+
+    def __init__(
+        self,
+        db_path: Union[str, Path],
+        auto_create: bool = True,
+        *,
+        use_wal: bool = True,
+        cache_keys_in_ram: bool = False,
+    ) -> None:
+        super().__init__(
+            db_path,
+            auto_create,
+            use_wal=use_wal,
+            cache_keys_in_ram=cache_keys_in_ram,
+        )
+
+    @classmethod
+    def open(
+        cls,
+        db_path: Union[str, Path],
+        *,
+        auto_create: bool = True,
+        use_wal: bool = True,
+        cache_keys_in_ram: bool = False,
+    ) -> "_SyncCacheDBOpenContext":
+        path_obj = Path(db_path)
+        if not auto_create and not path_obj.exists():
+            raise RuntimeError(f"Database file {db_path} does not exist")
+        return _SyncCacheDBOpenContext(
+            cls,
+            str(path_obj),
+            auto_create,
+            use_wal,
+            cache_keys_in_ram,
+        )
+
+    def init(self) -> None:
+        super().init()
+        if self._cache_keys_in_ram:
+            rows = self.query_many("SELECT key, expire_utc FROM cache")
+            self._reload_ram_index(rows)
 
     def migrations(self):
         return [
@@ -26,17 +69,27 @@ class SyncCacheDB(SyncBaseDB):
 
     @require_init
     def get(self, key: str, default: Any = None) -> Any:
+        now = datetime.now(timezone.utc)
+        cached_presence = self._ram_has_key(key, now)
+        if cached_presence is False:
+            return default
         row = self.query_one("SELECT value, expire_utc FROM cache WHERE key=?", (key,))
         if row is None:
+            self._ram_mark_miss(key)
             return default
         expire_utc = row["expire_utc"]
         if expire_utc is not None:
-            if datetime.fromisoformat(expire_utc) <= datetime.now(timezone.utc):
+            expire_dt = datetime.fromisoformat(expire_utc)
+            if expire_dt <= now:
+                self._ram_mark_miss(key)
                 return default
         return pickle.loads(row["value"])
 
     @require_init
     def is_set(self, key: str) -> bool:
+        cached_presence = self._ram_has_key(key, datetime.now(timezone.utc))
+        if cached_presence is not None:
+            return cached_presence
         exists = self.query_scalar(
             "SELECT 1 FROM cache WHERE key=? AND (expire_utc IS NULL OR expire_utc > ?)",
             (key, datetime.now(timezone.utc).isoformat()),
@@ -47,28 +100,42 @@ class SyncCacheDB(SyncBaseDB):
     def set(self, key: str, value: Any, expire_sec: Optional[int] = None) -> None:
         now = datetime.now(timezone.utc)
         if expire_sec is None:
-            expire_utc = None
+            expire_dt: Optional[datetime] = None
         elif expire_sec > 0:
-            expire_utc = now + timedelta(seconds=expire_sec)
+            expire_dt = now + timedelta(seconds=expire_sec)
         else:
-            expire_utc = now
+            expire_dt = now
         blob = sqlite3.Binary(pickle.dumps(value))
         row = {
             "key": key,
             "value": blob,
-            "expire_utc": expire_utc.isoformat() if expire_utc else None,
+            "expire_utc": expire_dt.isoformat() if expire_dt else None,
         }
         self.upsert_one("cache", row)
+        self._ram_on_set(key, expire_dt, now)
 
     @require_init
     def delete(self, key: str) -> int:
+        now = datetime.now(timezone.utc)
         cur = self.execute("DELETE FROM cache WHERE key=?", (key,))
+        self._ram_on_delete(key, now)
         return cur.rowcount
 
     @require_init
     def del_many(self, key_mask: str) -> int:
         pattern = key_mask.replace("_", "\\_").replace("*", "%")
+        keys_to_remove: List[str] = []
+        if self._cache_keys_in_ram:
+            keys_to_remove = [
+                str(key)
+                for key in self.query_column(
+                    "SELECT key FROM cache WHERE key LIKE ? ESCAPE '\\'",
+                    (pattern,),
+                )
+            ]
         cur = self.execute("DELETE FROM cache WHERE key LIKE ? ESCAPE '\\'", (pattern,))
+        if self._cache_keys_in_ram:
+            self._ram_on_del_many(keys_to_remove, datetime.now(timezone.utc))
         return cur.rowcount
 
     @require_init
@@ -82,6 +149,7 @@ class SyncCacheDB(SyncBaseDB):
     @require_init
     def clear(self) -> int:
         cur = self.execute("DELETE FROM cache")
+        self._ram_on_clear()
         return cur.rowcount
 
     def cache(
@@ -110,9 +178,33 @@ class SyncCacheDB(SyncBaseDB):
     @run_every_seconds(5)
     @require_init
     def _cleanup(self) -> None:
+        now = datetime.now(timezone.utc)
         self.execute(
             "DELETE FROM cache WHERE expire_utc IS NOT NULL AND expire_utc <= ?",
-            (datetime.now(timezone.utc).isoformat(),),
+            (now.isoformat(),),
         )
+        self._ram_purge_expired(now)
 
 
+class _SyncCacheDBOpenContext(_SyncDBOpenContext["SyncCacheDB"]):
+    def __init__(
+        self,
+        cls,
+        db_path: str,
+        auto_create: bool,
+        use_wal: bool,
+        cache_keys_in_ram: bool,
+    ) -> None:
+        super().__init__(cls, db_path, auto_create, use_wal)
+        self._cache_keys_in_ram = cache_keys_in_ram
+
+    def _open(self) -> "SyncCacheDB":
+        instance: SyncCacheDB = self._cls(  # type: ignore[call-arg]
+            self._db_path,
+            auto_create=self._auto_create,
+            use_wal=self._use_wal,
+            cache_keys_in_ram=self._cache_keys_in_ram,
+        )
+        instance.init()
+        self._db = instance
+        return instance

--- a/tests/test_abstractdb_misc.py
+++ b/tests/test_abstractdb_misc.py
@@ -1,0 +1,44 @@
+import pytest
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+from scriptdb.abstractdb import AbstractBaseDB, require_init
+
+
+@pytest.mark.asyncio
+async def test_require_init_async_generator_guard():
+    class Dummy:
+        def __init__(self) -> None:
+            self.initialized = False
+            self.conn = None
+
+        @require_init
+        async def stream(self):
+            yield 1
+
+    dummy = Dummy()
+    agen = dummy.stream()
+    with pytest.raises(RuntimeError):
+        await agen.__anext__()
+    await agen.aclose()
+
+
+def test_abstract_base_db_requires_existing_file(tmp_path):
+    class DummyDB(AbstractBaseDB):
+        def migrations(self):
+            return []
+
+    missing = tmp_path / "missing.db"
+    with pytest.raises(RuntimeError):
+        DummyDB(str(missing), auto_create=False)
+
+
+def test_abstract_base_db_migrations_not_implemented(tmp_path):
+    class DummyDB(AbstractBaseDB):
+        def migrations(self):
+            return super().migrations()
+
+    db = DummyDB(str(tmp_path / "dummy.db"))
+    with pytest.raises(NotImplementedError):
+        db.migrations()

--- a/tests/test_async_cachedb.py
+++ b/tests/test_async_cachedb.py
@@ -1,4 +1,6 @@
 import asyncio
+import logging
+from datetime import datetime, timedelta, timezone
 import pytest
 import pytest_asyncio
 import sys
@@ -120,3 +122,131 @@ async def test_async_with_closes(tmp_path):
     async with AsyncCacheDB.open(str(db_file), daemonize_thread=True) as db:
         await db.set("a", 1)
     assert db.initialized is False
+
+
+@pytest.mark.asyncio
+async def test_ram_index_initial_load_and_purge(tmp_path):
+    db_file = tmp_path / "ram_cache.db"
+    async with AsyncCacheDB.open(str(db_file), daemonize_thread=True) as db:
+        await db.set("keep", "v")
+        await db.set("stale", "v", expire_sec=0)
+
+    async with AsyncCacheDB.open(
+        str(db_file), daemonize_thread=True, cache_keys_in_ram=True
+    ) as db:
+        assert "keep" in db._ram_keys
+        assert "stale" not in db._ram_keys
+
+        await db.set("soon", "v", expire_sec=1)
+        assert "soon" in db._ram_keys
+        await asyncio.sleep(1.1)
+        await db.set("later", "v")
+        assert "soon" not in db._ram_keys
+
+
+@pytest.mark.asyncio
+async def test_ram_index_short_circuits_db_calls(tmp_path, monkeypatch):
+    db_file = tmp_path / "ram_cache.db"
+    async with AsyncCacheDB.open(
+        str(db_file), daemonize_thread=True, cache_keys_in_ram=True
+    ) as db:
+
+        async def forbid_query(*args, **kwargs):
+            raise AssertionError("RAM index should avoid hitting the database")
+
+        monkeypatch.setattr(db, "query_one", forbid_query)
+        monkeypatch.setattr(db, "query_scalar", forbid_query)
+
+        assert await db.get("missing") is None
+        assert await db.is_set("missing") is False
+
+        await db.set("present", "v")
+        assert await db.is_set("present") is True
+        await db.delete("present")
+        assert await db.is_set("present") is False
+        assert await db.get("present") is None
+
+
+@pytest.mark.asyncio
+async def test_async_cache_open_requires_existing_file(tmp_path):
+    missing = tmp_path / "nope.db"
+    with pytest.raises(RuntimeError):
+        AsyncCacheDB.open(str(missing), auto_create=False)
+    with pytest.raises(RuntimeError):
+        AsyncCacheDB(str(missing), auto_create=False)
+
+
+@pytest.mark.asyncio
+async def test_ram_index_marks_missing_rows_on_get(tmp_path):
+    db_file = tmp_path / "ram_stale.db"
+    async with AsyncCacheDB.open(
+        str(db_file), daemonize_thread=True, cache_keys_in_ram=True
+    ) as db:
+        await db.set("ghost", "v")
+        await db.execute("DELETE FROM cache WHERE key=?", ("ghost",))
+        assert "ghost" in db._ram_keys
+
+        assert await db.get("ghost") is None
+        assert "ghost" not in db._ram_keys
+
+
+@pytest.mark.asyncio
+async def test_ram_index_purges_expired_rows_on_get(tmp_path):
+    db_file = tmp_path / "ram_expire.db"
+    async with AsyncCacheDB.open(
+        str(db_file), daemonize_thread=True, cache_keys_in_ram=True
+    ) as db:
+        await db.set("ttl", "v", expire_sec=10)
+        past = (datetime.now(timezone.utc) - timedelta(seconds=5)).isoformat()
+        await db.execute("UPDATE cache SET expire_utc=? WHERE key=?", (past, "ttl"))
+
+        assert await db.get("ttl") is None
+        assert "ttl" not in db._ram_keys
+
+
+@pytest.mark.asyncio
+async def test_ram_index_del_many_and_clear(tmp_path):
+    db_file = tmp_path / "ram_bulk.db"
+    async with AsyncCacheDB.open(
+        str(db_file), daemonize_thread=True, cache_keys_in_ram=True
+    ) as db:
+        await db.set("user:1", 1)
+        await db.set("user:2", 2)
+        await db.set("other", 3)
+
+        removed = await db.del_many("user:*")
+        assert removed == 2
+        assert sorted(db._ram_keys) == ["other"]
+
+        await db.clear()
+        assert db._ram_keys == {}
+        assert db._ram_entries == []
+        assert db._ram_scores == []
+
+
+@pytest.mark.asyncio
+async def test_ram_index_reload_logs_memory_usage(tmp_path, caplog):
+    db_file = tmp_path / "ram_log.db"
+    async with AsyncCacheDB.open(str(db_file), daemonize_thread=True) as db:
+        await db.set("keep", "value")
+
+    caplog.set_level(logging.DEBUG, logger="scriptdb._cache_index")
+    async with AsyncCacheDB.open(
+        str(db_file), daemonize_thread=True, cache_keys_in_ram=True
+    ) as db:
+        assert "Reloaded RAM cache index" in caplog.text
+        assert "keep" in db._ram_keys
+
+
+@pytest.mark.asyncio
+async def test_ram_has_key_evicts_expired_entry(tmp_path):
+    db_file = tmp_path / "ram_has_key.db"
+    async with AsyncCacheDB.open(
+        str(db_file), daemonize_thread=True, cache_keys_in_ram=True
+    ) as db:
+        past = datetime.now(timezone.utc) - timedelta(seconds=1)
+        with db._ram_lock:
+            db._ram_insert_unlocked("expired", past)
+
+        assert await db.is_set("expired") is False
+        assert "expired" not in db._ram_keys


### PR DESCRIPTION
## Summary
- make the cache key index mixin short-circuit when the RAM cache is disabled and avoid unnecessary locking
- rely on the mixin helpers inside the async and sync cache databases instead of duplicating feature-flag checks

## Testing
- `ruff check .`
- `mypy src/scriptdb`
- `pytest --cov=scriptdb --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68ccf7c594908324b245bc48c4889dc1