### PR TITLE
Prepare 1.0.9 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog of the ScriptDB
 
+## 1.0.9 - Configurable row factories
+
+- Added `row_factory` option to async and sync base databases, cache wrappers, and context managers with support for `sqlite3.Row` or plain dict results
+- Documented row factory usage and added tests covering both row types across query helpers
+
 ## 1.0.8 - Added RAM key index, also reduce routine logging noise
 
 - Added RAM key index for sync and async cachedb, with cache_keys_in_ram=True it can speadup keys existing checks with some additional RAM usage

--- a/README.md
+++ b/README.md
@@ -308,6 +308,30 @@ status_by_url = await db.query_dict(
 )
 ```
 
+### Controlling the row factory
+
+`AsyncBaseDB` and `SyncBaseDB` return [`sqlite3.Row`](https://docs.python.org/3/library/sqlite3.html#row-objects)
+instances by default. Pass `row_factory=dict` to either the constructor or the
+`open()` helper to receive plain dictionaries instead.
+
+```python
+# Async example
+async with MyDB.open("app.db", row_factory=dict) as db:
+    row = await db.query_one("SELECT * FROM links LIMIT 1")
+    assert isinstance(row, dict)
+
+# Sync example (using your SyncBaseDB subclass)
+with MySyncDB.open("app.db", row_factory=dict) as db:
+    row = db.query_one("SELECT * FROM links LIMIT 1")
+    assert isinstance(row, dict)
+```
+
+The choice affects every method that previously returned `sqlite3.Row`
+instances (`query_one`, `query_many`, `query_many_gen`, and the default values
+from `query_dict`) as well as helpers like `query_scalar` and `query_column`.
+This makes it easy to integrate ScriptDB with codebases that prefer working
+with JSON-serialisable dictionaries instead of custom row objects.
+
 ## Useful implementations
 
 ### CacheDB

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scriptdb"
-version = "1.0.8"
+version = "1.0.9"
 description = "Simple SQLite sync/async wrapper with migration support for use in ad-hoc scripts"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/scriptdb/_rowfactory.py
+++ b/src/scriptdb/_rowfactory.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import inspect
+import sqlite3
+from typing import Any, Dict, Sequence, Tuple, Type, Union, cast
+
+RowDict = Dict[str, Any]
+RowType = Union[sqlite3.Row, RowDict]
+RowFactorySetting = Union[Type[sqlite3.Row], Type[dict]]
+
+
+def normalize_row_factory(row_factory: RowFactorySetting) -> Tuple[RowFactorySetting, bool]:
+    if row_factory is dict:
+        return dict, True
+    if row_factory is sqlite3.Row:
+        return sqlite3.Row, False
+    raise TypeError("row_factory must be either dict or sqlite3.Row")
+
+
+def dict_row_factory(cursor: "sqlite3.Cursor", row: Sequence[Any]) -> RowDict:
+    """sqlite3 row factory that returns plain dictionaries."""
+
+    return {description[0]: row[idx] for idx, description in enumerate(cursor.description or [])}
+
+
+def first_column_value(row: RowType, rows_as_dict: bool) -> Any:
+    if rows_as_dict:
+        values = cast(RowDict, row).values()
+        return next(iter(values), None)
+    row_obj = cast(sqlite3.Row, row)
+    return row_obj[0]
+
+
+def supports_row_factory(cls: Type[Any]) -> bool:
+    """Return True if *cls*'s __init__ accepts a row_factory argument."""
+
+    try:
+        signature = inspect.signature(cls.__init__)
+    except (TypeError, ValueError):  # pragma: no cover - builtins or exotic callables
+        return True
+
+    for parameter in signature.parameters.values():
+        if parameter.kind == inspect.Parameter.VAR_KEYWORD:
+            return True
+    return "row_factory" in signature.parameters
+

--- a/src/scriptdb/asynccachedb.py
+++ b/src/scriptdb/asynccachedb.py
@@ -5,11 +5,12 @@ import pickle
 import sqlite3
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Callable, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from ._cache_index import _CacheKeyIndexMixin
 from .abstractdb import run_every_seconds, require_init
-from .asyncdb import AsyncBaseDB, _AsyncDBOpenContext
+from ._rowfactory import supports_row_factory
+from .asyncdb import AsyncBaseDB, _AsyncDBOpenContext, RowFactorySetting
 
 
 class AsyncCacheDB(_CacheKeyIndexMixin, AsyncBaseDB):
@@ -21,6 +22,7 @@ class AsyncCacheDB(_CacheKeyIndexMixin, AsyncBaseDB):
         auto_create: bool = True,
         *,
         use_wal: bool = True,
+        row_factory: RowFactorySetting = sqlite3.Row,
         daemonize_thread: bool = False,
         cache_keys_in_ram: bool = False,
     ) -> None:
@@ -28,6 +30,7 @@ class AsyncCacheDB(_CacheKeyIndexMixin, AsyncBaseDB):
             db_path,
             auto_create,
             use_wal=use_wal,
+            row_factory=row_factory,
             daemonize_thread=daemonize_thread,
             cache_keys_in_ram=cache_keys_in_ram,
         )
@@ -39,6 +42,7 @@ class AsyncCacheDB(_CacheKeyIndexMixin, AsyncBaseDB):
         *,
         auto_create: bool = True,
         use_wal: bool = True,
+        row_factory: RowFactorySetting = sqlite3.Row,
         daemonize_thread: bool = False,
         cache_keys_in_ram: bool = False,
     ) -> "_AsyncCacheDBOpenContext":
@@ -50,6 +54,7 @@ class AsyncCacheDB(_CacheKeyIndexMixin, AsyncBaseDB):
             str(path_obj),
             auto_create,
             use_wal,
+            row_factory,
             daemonize_thread,
             cache_keys_in_ram,
         )
@@ -196,20 +201,27 @@ class _AsyncCacheDBOpenContext(_AsyncDBOpenContext["AsyncCacheDB"]):
         db_path: str,
         auto_create: bool,
         use_wal: bool,
+        row_factory: RowFactorySetting,
         daemonize_thread: bool,
         cache_keys_in_ram: bool,
     ) -> None:
-        super().__init__(cls, db_path, auto_create, use_wal, daemonize_thread)
+        super().__init__(cls, db_path, auto_create, use_wal, daemonize_thread, row_factory)
         self._cache_keys_in_ram = cache_keys_in_ram
 
     async def _open(self) -> "AsyncCacheDB":
-        instance: AsyncCacheDB = self._cls(  # type: ignore[call-arg]
-            self._db_path,
-            auto_create=self._auto_create,
-            use_wal=self._use_wal,
-            daemonize_thread=self._daemonize_thread,
-            cache_keys_in_ram=self._cache_keys_in_ram,
-        )
+        kwargs: Dict[str, Any] = {
+            "auto_create": self._auto_create,
+            "use_wal": self._use_wal,
+            "daemonize_thread": self._daemonize_thread,
+            "cache_keys_in_ram": self._cache_keys_in_ram,
+        }
+        if supports_row_factory(self._cls):
+            kwargs["row_factory"] = self._row_factory
+            instance = self._cls(self._db_path, **kwargs)  # type: ignore[call-arg]
+        else:
+            instance = self._cls(self._db_path, **kwargs)  # type: ignore[call-arg]
+            if hasattr(instance, "_set_row_factory"):
+                instance._set_row_factory(self._row_factory)  # type: ignore[attr-defined]
         await instance.init()
         instance._register_signal_handlers()
         self._db = instance


### PR DESCRIPTION
## Summary
- factor shared row factory utilities into a dedicated helper and reuse them in async and sync base classes
- ensure open contexts and cache wrappers validate row_factory upfront and only pass it when supported
- document row_factory configuration alongside the query helper documentation
- bump the package version to 1.0.9 and record the row_factory feature set in the changelog

## Testing
- ruff check .
- mypy src/scriptdb
- pytest --cov=scriptdb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e604c8fbd08324b31207e7e687cedc